### PR TITLE
Fix sdl2_image include statement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 find_package(SDL2 REQUIRED)
 find_package(SDL2_image REQUIRED)
 include_directories(${SDL2_INCLUDE_DIRS})
-include_directories(${SDL2_IMAGE_DIRS})
+include_directories(${SDL2_IMAGE_INCLUDE_DIRS})
 
 add_executable(SDL2Test WIN32 Main.cpp)
 target_link_libraries(SDL2Test ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES})


### PR DESCRIPTION
I'm fairly sure this is meant to be using `SDL2_IMAGE_INCLUDE_DIRS` which is defined in `FindSDL2_image.cmake`.